### PR TITLE
Fix Brotato loading freeze with timeout and parallel loading

### DIFF
--- a/src/game/BrotatoGame.js
+++ b/src/game/BrotatoGame.js
@@ -108,20 +108,31 @@ export class BrotatoGame {
       { key: 'bullet', path: 'assets/sprites/bullets/frame0000.png' }
     ];
 
-    this.diagnostic(`Loading ${assetsToLoad.length} assets...`);
+    this.diagnostic(`Loading ${assetsToLoad.length} assets in parallel...`);
 
-    for (const asset of assetsToLoad) {
+    // Load all assets in parallel for better performance
+    const loadPromises = assetsToLoad.map(async (asset) => {
       try {
         this.diagnostic(`Loading ${asset.key} from ${asset.path}...`);
-        this.textures[asset.key] = await this.textureLoader.loadTexture(asset.path);
+        const texture = await this.textureLoader.loadTexture(asset.path);
         this.diagnostic(`✓ Loaded ${asset.key}`);
+        return { key: asset.key, texture, success: true };
       } catch (error) {
         this.diagnostic(`⚠ Failed to load ${asset.key}, using fallback (${error.message})`);
-        this.textures[asset.key] = null; // Will use colored circles as fallback
+        return { key: asset.key, texture: null, success: false };
       }
+    });
+
+    // Wait for all assets to load (or fail)
+    const results = await Promise.all(loadPromises);
+
+    // Store the results
+    for (const result of results) {
+      this.textures[result.key] = result.texture;
     }
 
-    this.diagnostic('All assets processed');
+    const successCount = results.filter(r => r.success).length;
+    this.diagnostic(`All assets processed: ${successCount}/${assetsToLoad.length} loaded successfully`);
   }
 
   createPlayer() {

--- a/src/renderer/TextureLoader.js
+++ b/src/renderer/TextureLoader.js
@@ -36,13 +36,30 @@ export class TextureLoader {
     }
   }
 
-  async _loadTextureInternal(url) {
+  async _loadTextureInternal(url, timeoutMs = 10000) {
     const gl = this.gl;
 
     return new Promise((resolve, reject) => {
       const image = new Image();
+      let timeoutId = null;
+      let resolved = false;
+
+      // Timeout handler
+      const timeout = () => {
+        if (!resolved) {
+          resolved = true;
+          image.onload = null;
+          image.onerror = null;
+          image.src = '';
+          reject(new Error(`Timeout loading texture: ${url}`));
+        }
+      };
 
       image.onload = () => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeoutId);
+
         const texture = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_2D, texture);
 
@@ -64,8 +81,14 @@ export class TextureLoader {
       };
 
       image.onerror = () => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeoutId);
         reject(new Error(`Failed to load texture: ${url}`));
       };
+
+      // Start timeout
+      timeoutId = setTimeout(timeout, timeoutMs);
 
       // Handle relative paths for GitHub Pages
       image.src = url;


### PR DESCRIPTION
The game was freezing during asset loading at "loading legs" or "loading bullet"
because the TextureLoader had no timeout mechanism. If an image failed to load
or took too long, the Promise would hang indefinitely.

Changes:
- Add 10-second timeout to image loading in TextureLoader
- Prevent infinite hangs by rejecting the promise on timeout
- Clean up image resources when timeout occurs
- Optimize asset loading to be parallel instead of sequential
- Improve error handling and diagnostic messages

This ensures the game will always complete loading (with fallbacks if needed)
rather than freezing indefinitely.