### PR TITLE
Add rotating bosses with distinct AI patterns and enemy projectiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A polished single-file hybrid of tower defense and arena survival. Pilot the gro
 - **6 defense types** — Acorn Turret, Beehive (splash), Sprinkler (slow), Thorn Launcher (pierce), Storm Totem (chain lightning), Sunflower (aura buffs) — each upgradable to level 8, sellable, with a click-to-select stats panel
 - **Player progression** — enemies drop XP orbs; each level presents a 3-card perk draft (damage, fire rate, crits, split shot, regen, magnets, tower buffs, discounts…)
 - **Meta-progression** — runs bank 🥕 Carrots based on waves, kills, and boss takedowns; spend them in the Burrow on **4 playable classes** (Classic, Burly, Hawkeye, Hoarder Chuck) and **3 permanent upgrade tracks** (starting cash, damage, XP gain) — all persisted between sessions
-- **7 pest types** — rats, mosquitoes, boars, splitting rabbits, loot raccoons — and the Grizzly boss every 5 waves with its own HP bar
+- **7 pest types** — rats, mosquitoes, boars, splitting rabbits, loot raccoons — plus **3 rotating bosses** every 5 waves, each with its own AI pattern and HP bar: the charging Grizzly, the minion-summoning Fox, and the feather-strafing Hawk
 - **Wave modifiers** — every wave rolls a twist (Farmers Market, Morning Buzz, Cold Snap, Hailstorm, Fertile Grounds)
 - **Groundhog Rage & combo system** — kills charge a global overdrive; kill streaks stack damage bonuses
 - **Juice** — particles, screen shake, floating text, bullet trails, chain-lightning arcs, low-HP vignette, synth SFX and a generative soundtrack (WebAudio, no assets)

--- a/arena.html
+++ b/arena.html
@@ -191,7 +191,7 @@
           <b>Move</b> with <span class="key">W</span><span class="key">A</span><span class="key">S</span><span class="key">D</span> — your groundhog auto-fires at the nearest pest.<br>
           <b>Build defenses</b> from the dock (<span class="key">1</span>–<span class="key">6</span>), then click the yard to place them.<br>
           <b>Click a tower</b> to upgrade or sell it. Kills earn <b style="color:var(--gold)">cash</b> for towers and <b style="color:#c5e1a5">XP</b> for level-up perks.<br>
-          <b>Groundhog Rage</b> <span class="key">Space</span> when the meter is full. The Grizzly comes every 5 waves. Defend the burrow.
+          <b>Groundhog Rage</b> <span class="key">Space</span> when the meter is full. A boss prowls in every 5 waves — Grizzly, Fox, or Hawk. Defend the burrow.
         </div>
         <div class="diff-row" id="diffRow">
           <button class="diff" data-d="Easy">EASY</button>
@@ -372,8 +372,11 @@ const ENEMY_TYPES={
   splitter:{icon:'🐇',hp:46,spd:64, reward:10,xp:3, dmg:8, r:15,color:'#e5e7eb'},
   mini:   {icon:'🐰',hp:12, spd:100,reward:2, xp:1, dmg:4, r:8, color:'#f9a8d4'},
   rich:   {icon:'🦝',hp:42, spd:80, reward:34,xp:4, dmg:6, r:13,color:'#ffb347'},
-  boss:   {icon:'🐻',hp:950,spd:33, reward:130,xp:40,dmg:22,r:32,color:'#ff6b5d',armor:5,boss:true}
+  boss:   {icon:'🐻',hp:950,spd:33, reward:130,xp:40,dmg:22,r:32,color:'#ff6b5d',armor:5,boss:true,ai:'charge',name:'THE GRIZZLY'},
+  bossFox:{icon:'🦊',hp:720,spd:60, reward:130,xp:40,dmg:16,r:26,color:'#f97316',armor:4,boss:true,ai:'summon',name:'THE FOX'},
+  bossHawk:{icon:'🦅',hp:800,spd:75,reward:130,xp:40,dmg:14,r:26,color:'#cbd5e1',armor:3,boss:true,ai:'dive',name:'THE HAWK'}
 };
+function bossForWave(w){return ['boss','bossFox','bossHawk'][(Math.floor(w/5)-1)%3]}
 
 /* ---------- wave events ---------- */
 const WAVE_EVENTS=[
@@ -466,7 +469,7 @@ function freshState(difficulty){
     autoStart:false,
     speed:1,
     kills:0,cashEarned:0,towersBuilt:0,bossKills:0,cls:META.cls,
-    towers:[],enemies:[],bullets:[],orbs:[],particles:[],floats:[],lightning:[],pulses:[],toasts:[],
+    towers:[],enemies:[],bullets:[],eBullets:[],orbs:[],particles:[],floats:[],lightning:[],pulses:[],toasts:[],
     mods:{...BASE_MODS},activeEvent:null,
     hype:0,hypeMax:100,hypeTimer:0,
     combo:0,comboTimer:0,
@@ -595,7 +598,8 @@ function spawnEnemy(type,px,py){
     armor:(t.armor||0)+(state.wave-1)*0.3,
     reward:Math.round(t.reward*(1+0.02*(state.wave-1))*m.enemyRewardMult),
     xp:t.xp,dmg:Math.round(t.dmg*D.dmg*Math.min(2,1+(state.wave-1)*0.03)),
-    alive:true,slowTimer:0,slowFactor:1,hitFlash:0,touchCd:0,wob:rand(0,TAU)
+    alive:true,slowTimer:0,slowFactor:1,hitFlash:0,touchCd:0,wob:rand(0,TAU),
+    ai:t.ai||null,name:t.name||null,phase:'walk',phaseT:2,summonT:3.5,shootT:2.2,diveT:6,chargeDir:null,dmgMult:1
   };
   e.maxHp=e.hp;
   state.enemies.push(e);
@@ -636,6 +640,77 @@ function killEnemy(e){
     spawnEnemy('mini',e.x-10,e.y);spawnEnemy('mini',e.x+10,e.y);
   }
 }
+function updateBossAI(e,dt,p,dx,dy,d,spd){
+  e.dmgMult=1;
+  if(e.ai==='charge'){
+    e.phaseT-=dt;
+    if(e.phase==='walk'){
+      e.x+=dx/d*spd*0.8*dt;e.y+=dy/d*spd*0.8*dt;
+      if(e.phaseT<=0){e.phase='windup';e.phaseT=0.8}
+    }else if(e.phase==='windup'){
+      if(e.phaseT<=0){
+        e.chargeDir={x:dx/d,y:dy/d};
+        e.phase='charge';e.phaseT=0.85;
+        shake(3);Audio2.sfx.boss();
+      }
+    }else{
+      e.x+=e.chargeDir.x*spd*6*dt;e.y+=e.chargeDir.y*spd*6*dt;
+      e.dmgMult=1.6;
+      if(Math.random()<0.5)spawnParticles(e.x,e.y,'#ff6b5d',1,60,0.3);
+      const hitWall=e.x<e.r||e.x>W-e.r||e.y<e.r||e.y>H-e.r;
+      if(hitWall){shake(7);spawnParticles(e.x,e.y,'#ff6b5d',14,180)}
+      if(hitWall||e.phaseT<=0){
+        e.x=clamp(e.x,e.r,W-e.r);e.y=clamp(e.y,e.r,H-e.r);
+        e.phase='walk';e.phaseT=2.2;
+      }
+    }
+  }else if(e.ai==='summon'){
+    const desired=230;let mx,my;
+    if(d<desired-20){mx=-dx/d;my=-dy/d}
+    else if(d>desired+50){mx=dx/d;my=dy/d}
+    else{mx=-dy/d;my=dx/d}
+    e.x=clamp(e.x+mx*spd*dt,e.r,W-e.r);e.y=clamp(e.y+my*spd*dt,e.r,H-e.r);
+    e.summonT-=dt;
+    if(e.summonT<=0){
+      e.summonT=6;
+      if(state.enemies.length<80){
+        const n=Math.min(4,2+Math.floor(state.wave/10));
+        for(let i=0;i<n;i++)spawnEnemy(pick(['grunt','mini','fast']),clamp(e.x+rand(-45,45),10,W-10),clamp(e.y+rand(-45,45),10,H-10));
+        addPulse(e.x,e.y,90,'#f97316',0.5);
+        spawnParticles(e.x,e.y,'#f97316',10,120);
+        Audio2.sfx.wave();
+      }
+    }
+  }else if(e.ai==='dive'){
+    e.diveT-=dt;e.shootT-=dt;
+    if(e.phase==='charge'){
+      e.phaseT-=dt;
+      e.x+=e.chargeDir.x*spd*4.5*dt;e.y+=e.chargeDir.y*spd*4.5*dt;
+      e.dmgMult=1.4;
+      const out=e.x<e.r||e.x>W-e.r||e.y<e.r||e.y>H-e.r;
+      if(out||e.phaseT<=0){e.x=clamp(e.x,e.r,W-e.r);e.y=clamp(e.y,e.r,H-e.r);e.phase='walk'}
+    }else{
+      const desired=250;let mx,my;
+      if(d>desired+40){mx=dx/d;my=dy/d}
+      else if(d<desired-40){mx=-dx/d*0.6;my=-dy/d*0.6}
+      else{mx=-dy/d;my=dx/d}
+      e.x=clamp(e.x+mx*spd*dt,e.r,W-e.r);e.y=clamp(e.y+my*spd*dt,e.r,H-e.r);
+      if(e.shootT<=0){
+        e.shootT=3.2;
+        const base=Math.atan2(dy,dx);
+        for(let i=-1;i<=1;i++){
+          const a=base+i*0.22;
+          state.eBullets.push({x:e.x,y:e.y,vx:Math.cos(a)*190,vy:Math.sin(a)*190,r:5,dmg:Math.round(10+state.wave*0.4),ttl:4});
+        }
+        Audio2.sfx.shoot();
+      }
+      if(e.diveT<=0){
+        e.diveT=8;e.phase='charge';e.phaseT=0.8;e.chargeDir={x:dx/d,y:dy/d};
+        shake(2);Audio2.sfx.boss();
+      }
+    }
+  }
+}
 function updateEnemy(e,dt){
   if(!e.alive)return;
   e.slowTimer=Math.max(0,e.slowTimer-dt);
@@ -646,12 +721,14 @@ function updateEnemy(e,dt){
   const p=state.player;
   const dx=p.x-e.x,dy=p.y-e.y,d=Math.hypot(dx,dy)||1;
   const spd=e.spd*e.slowFactor;
-  e.x+=dx/d*spd*dt;e.y+=dy/d*spd*dt;
-  if(d<e.r+p.r&&e.touchCd<=0){
-    hurtPlayer(e.dmg);
+  if(e.ai)updateBossAI(e,dt,p,dx,dy,d,spd);
+  else{e.x+=dx/d*spd*dt;e.y+=dy/d*spd*dt}
+  const kx=p.x-e.x,ky=p.y-e.y,kd=Math.hypot(kx,ky)||1;
+  if(kd<e.r+p.r&&e.touchCd<=0){
+    hurtPlayer(Math.round(e.dmg*(e.dmgMult||1)));
     if(e.boss){
       e.touchCd=0.9;
-      const k=42/d;p.x=clamp(p.x+dx*-k,p.r,W-p.r);p.y=clamp(p.y+dy*-k,p.r,H-p.r);
+      const k=46/kd;p.x=clamp(p.x+kx*k,p.r,W-p.r);p.y=clamp(p.y+ky*k,p.r,H-p.r);
     }else{
       e.alive=false;
       spawnParticles(e.x,e.y,e.color,8,110);
@@ -865,8 +942,9 @@ function buildWavePlan(wave){
   if(wave>=6)push('grunt',n(3),gap(0.4));
   if(wave>=8)push('fast',n(2.5),gap(0.35));
   if(wave%5===0){
+    const type=bossForWave(wave);
     const bosses=1+Math.floor(wave/12);
-    for(let i=0;i<bosses;i++)plan.push({t:t+1+i*2.4,type:'boss'});
+    for(let i=0;i<bosses;i++)plan.push({t:t+1+i*2.4,type});
   }
   plan.sort((a,b)=>a.t-b.t);
   return plan;
@@ -883,7 +961,7 @@ function startWave(){
   state.wavePlan=buildWavePlan(state.wave);
   state.waveClock=0;
   state.waveActive=true;
-  addToast('WAVE '+state.wave+(state.wave%5===0?' — THE GRIZZLY':''),ev.name+' · '+ev.desc);
+  addToast('WAVE '+state.wave+(state.wave%5===0?' — '+ENEMY_TYPES[bossForWave(state.wave)].name:''),ev.name+' · '+ev.desc);
   if(state.wave%5===0){Audio2.sfx.boss();shake(4)}else Audio2.sfx.wave();
   updateDockState();
 }
@@ -1072,6 +1150,18 @@ function update(dt){
     if(b.ttl<=0||nx<-20||nx>W+20||ny<-20||ny>H+20){state.bullets.splice(i,1);continue}
     b.x=nx;b.y=ny;
   }
+  // enemy projectiles (hawk feathers)
+  for(let i=state.eBullets.length-1;i>=0;i--){
+    const b=state.eBullets[i];
+    b.x+=b.vx*dt;b.y+=b.vy*dt;b.ttl-=dt;
+    const pp=state.player;
+    if(dist(b.x,b.y,pp.x,pp.y)<pp.r+b.r){
+      hurtPlayer(b.dmg);
+      spawnParticles(b.x,b.y,'#fca5a5',5,90,0.35);
+      state.eBullets.splice(i,1);continue;
+    }
+    if(b.ttl<=0||b.x<-20||b.x>W+20||b.y<-20||b.y>H+20)state.eBullets.splice(i,1);
+  }
   // fx
   for(let i=state.particles.length-1;i>=0;i--){
     const p=state.particles[i];
@@ -1189,6 +1279,11 @@ function draw(){
       ctx.strokeStyle='rgba(85,200,240,0.6)';ctx.lineWidth=1.5;
       ctx.beginPath();ctx.arc(e.x,e.y,e.r+8,0,TAU);ctx.stroke();
     }
+    if(e.ai==='charge'&&e.phase==='windup'){
+      const f=0.5+0.5*Math.sin(state.time*25);
+      ctx.strokeStyle=`rgba(255,107,93,${0.35+0.45*f})`;ctx.lineWidth=3;
+      ctx.beginPath();ctx.arc(e.x,e.y,e.r+11,0,TAU);ctx.stroke();
+    }
   }
   // player
   const p=state.player;
@@ -1220,6 +1315,13 @@ function draw(){
     ctx.globalAlpha=1;
     ctx.fillStyle=b.color;
     ctx.beginPath();ctx.arc(b.x,b.y,b.r,0,TAU);ctx.fill();
+  }
+  // enemy projectiles
+  for(const b of state.eBullets){
+    ctx.strokeStyle='#fca5a5';ctx.globalAlpha=0.45;ctx.lineWidth=3;
+    ctx.beginPath();ctx.moveTo(b.x-b.vx*0.04,b.y-b.vy*0.04);ctx.lineTo(b.x,b.y);ctx.stroke();
+    ctx.globalAlpha=1;ctx.fillStyle='#ff8c7a';
+    ctx.beginPath();ctx.arc(b.x,b.y,b.r*0.8,0,TAU);ctx.fill();
   }
   // lightning
   for(const l of state.lightning){
@@ -1289,7 +1391,7 @@ function draw(){
     ctx.fillStyle='#ff5d73';ctx.fillRect(bx,by,bw*(boss.hp/boss.maxHp),10);
     ctx.strokeStyle='rgba(255,93,115,0.5)';ctx.strokeRect(bx-2,by-2,bw+4,14);
     ctx.fillStyle='#ffc3b8';ctx.font='900 11px system-ui';ctx.textAlign='center';
-    ctx.fillText('⚠ THE GRIZZLY ⚠',W/2,by+24);
+    ctx.fillText('⚠ '+(boss.name||'BOSS')+' ⚠',W/2,by+24);
   }
   // toasts
   let ty=boss?86:64;


### PR DESCRIPTION
## Summary

Boss waves now cycle through **three bosses**, each with its own AI pattern, instead of a single walk-at-you boss:

- 🐻 **The Grizzly** (waves 5, 20, …) — stalks the player, telegraphs with a pulsing red ring, then launches a high-speed charge with 1.6× contact damage and wall-slam screen shake. Sprinkler slows affect the charge for counterplay.
- 🦊 **The Fox** (waves 10, 25, …) — keeps its distance and strafes around the player, periodically summoning packs of pests at its position.
- 🦅 **The Hawk** (waves 15, 30, …) — circles at range firing 3-way feather spreads the player must dodge (new enemy-projectile system), with periodic dive attacks.

### Supporting changes
- New enemy-projectile system (`eBullets`): movement, player collision with particle impact, trailed dart rendering
- Boss HP bar and wave-start toast display the incoming boss's name
- **Bug fix:** boss contact knockback was pushing the player *toward* the boss instead of away
- Menu copy updated to mention the boss roster

## Testing
- Playwright headless suite extended to **26 checks** — six new ones verify the boss rotation schedule (Fox on 10, Hawk on 15), the Grizzly windup→charge state machine, Hawk feather fire, feather damage to the player, and Fox minion summons — all pass with zero console errors
- Boss-fight scene visually verified (named boss bar, telegraph ring, feather volleys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XatLZk4edckWE1X3n3tvJk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XatLZk4edckWE1X3n3tvJk)_