### PR TITLE
Victory + endless elites, achievements, weapon classes, and groundhog gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A polished single-file hybrid of tower defense and arena survival. Pilot the gro
 - **7 pest types** — rats, mosquitoes, boars, splitting rabbits, loot raccoons — plus **3 rotating bosses** every 5 waves, each with its own AI pattern and HP bar: the charging Grizzly, the minion-summoning Fox, and the feather-strafing Hawk
 - **Wave modifiers** — every wave rolls a twist (Farmers Market, Morning Buzz, Cold Snap, Hailstorm, Fertile Grounds)
 - **Groundhog Rage & combo system** — kills charge a global overdrive; kill streaks stack damage bonuses
+- **Armory: 4 weapon classes** — Acorn Slinger (ranged), Claws & Tail (melee arc swipes with knockback and a 360° tail-spin every 4th hit), Seed Shotgun (5-pellet spray), Thorn Rifle (slow piercing sniper)
+- **Victory & Endless** — defend the yard through wave 20 for a carrot bonus, then push into Endless Mode where shielded/swift/enraged elite pests join every wave
+- **14 achievements** — persistent, each worth bonus carrots, shown in the Burrow
+- **A living groundhog** — waddles with dust puffs, faces its target, and when idle will sniff, look around, stretch, nibble a carrot, or doze off
 - **Juice** — particles, screen shake, floating text, bullet trails, chain-lightning arcs, low-HP vignette, synth SFX and a generative soundtrack (WebAudio, no assets)
 - **Quality of life** — pause, 1×/2×/3× speed, auto-start waves, difficulty select, persistent best wave, game-over stats + instant restart, full touch/mobile support
 - **Zero dependencies** — one self-contained HTML file, works from `file://`, GitHub Pages, or any static host

--- a/arena.html
+++ b/arena.html
@@ -95,6 +95,16 @@
   #goSpuds{color:var(--gold);font-weight:800;font-family:var(--mono);margin-bottom:10px;font-size:15px}
   @media (max-width:480px){.class-row{grid-template-columns:1fr}}
 
+  /* achievements */
+  .ach-head{display:flex;justify-content:space-between;align-items:center;margin:14px 0 8px}
+  .ach-head em{font-style:normal;font-size:11px;font-weight:800;letter-spacing:.16em;color:var(--dim)}
+  #achCount{font-family:var(--mono);font-size:11px;color:var(--dim)}
+  .ach-grid{display:flex;flex-wrap:wrap;gap:6px}
+  .ach{display:inline-flex;align-items:center;gap:5px;background:var(--panel2);border:1px solid var(--line);border-radius:999px;padding:4px 10px 4px 6px;font-size:11px;font-weight:700;color:var(--ink)}
+  .ach.locked{opacity:.38;filter:grayscale(1)}
+  .ach .ai2{font-size:13px}
+  #vicSpuds{color:var(--gold);font-weight:800;font-family:var(--mono);margin-bottom:10px;font-size:15px}
+
   /* level-up cards */
   .cards{display:flex;gap:12px;justify-content:center;margin-top:20px;flex-wrap:wrap}
   .card{flex:1;min-width:130px;max-width:160px;background:var(--panel2);border:1px solid var(--line);border-radius:14px;padding:16px 12px;cursor:pointer;transition:transform .12s ease,border-color .12s ease;text-align:center}
@@ -203,7 +213,11 @@
         <div class="locker">
           <div class="locker-head"><em>BURROW — RUNS EARN CARROTS</em><span id="spudBal">🥕 0</span></div>
           <div class="class-row" id="classRow"></div>
-          <div class="perm-row" id="permRow"></div>
+          <div class="ach-head" style="margin-top:12px"><em>ARMORY — WEAPONS</em><span></span></div>
+          <div class="class-row" id="weaponRow"></div>
+          <div class="perm-row" id="permRow" style="margin-top:12px"></div>
+          <div class="ach-head"><em>ACHIEVEMENTS</em><span id="achCount">0/0</span></div>
+          <div class="ach-grid" id="achGrid"></div>
         </div>
       </div>
     </div>
@@ -230,6 +244,20 @@
         <button class="bigbtn" id="againBtn">PLAY AGAIN</button>
         <div style="margin-top:10px"><button class="diff" id="menuBtn">BURROW &amp; MENU</button></div>
         <div class="best-line" id="goBest"></div>
+      </div>
+    </div>
+
+    <div class="overlay" id="victory" hidden>
+      <div class="sheet">
+        <div class="game-title" style="font-size:34px">🏆 YARD <span class="glow">DEFENDED</span></div>
+        <div class="tagline">Wave 20 conquered</div>
+        <div id="vicSpuds" style="margin-top:12px"></div>
+        <div class="howto" style="text-align:center">
+          The pests retreat… for now. Push on into <b>Endless Mode</b>, where
+          <b style="color:var(--danger)">elite pests</b> — shielded, swift, and enraged — join every wave.
+        </div>
+        <button class="bigbtn" id="endlessBtn">CONTINUE — ENDLESS</button>
+        <div style="margin-top:10px"><button class="diff" id="vicMenuBtn">BURROW &amp; MENU</button></div>
       </div>
     </div>
 
@@ -311,6 +339,7 @@ const Audio2=(()=>{
     wave(){tone(330,330,0.1,'square',0.05);setTimeout(()=>tone(440,440,0.1,'square',0.05),110);setTimeout(()=>tone(660,660,0.16,'square',0.055),220)},
     hype(){tone(180,1400,0.45,'sawtooth',0.07)},
     hurt(){tone(140,70,0.16,'sawtooth',0.09)},
+    swipe(){tone(260,90,0.09,'sawtooth',0.045)},
     boss(){tone(70,45,0.7,'sawtooth',0.1);tone(140,90,0.7,'square',0.05)},
     gameover(){[392,330,262,196].forEach((f,i)=>setTimeout(()=>tone(f,f*0.97,0.32,'triangle',0.07),i*180))},
     click(){tone(1100,900,0.03,'square',0.03)}
@@ -437,16 +466,75 @@ const PERMS=[
   {id:'power', icon:'💪',name:'Veggie Diet',  desc:'+8% groundhog damage', baseCost:80,growth:1.7,max:5},
   {id:'wisdom',icon:'🧠',name:'Burrow Wisdom',desc:'+10% XP gain',      baseCost:70,growth:1.7,max:3}
 ];
+const ACH_LIST=[
+  {id:'first',   icon:'🩸',name:'First Blood',    desc:'Defeat your first pest'},
+  {id:'w5',      icon:'🌊',name:'Making Waves',   desc:'Clear wave 5'},
+  {id:'w10',     icon:'🔥',name:'Double Digits',  desc:'Clear wave 10'},
+  {id:'w20',     icon:'🏆',name:'Yard Defended',  desc:'Clear wave 20'},
+  {id:'w30',     icon:'🌌',name:'Beyond the Fence',desc:'Clear wave 30'},
+  {id:'boss',    icon:'💪',name:'Boss Buster',    desc:'Defeat a boss'},
+  {id:'menagerie',icon:'🧩',name:'Full Menagerie',desc:'Defeat all 3 boss types'},
+  {id:'flawless',icon:'🛡️',name:'Untouchable',   desc:'Clear wave 3+ without damage'},
+  {id:'gardener',icon:'🌷',name:'Master Gardener',desc:'10 defenses at once'},
+  {id:'maxbloom',icon:'🌳',name:'Max Bloom',      desc:'Upgrade a defense to LV 8'},
+  {id:'combo15', icon:'⚡',name:'Chain ×15',      desc:'Reach a 15-kill combo'},
+  {id:'rich2k',  icon:'🤑',name:'Deep Pockets',   desc:'Hold $2000'},
+  {id:'classes', icon:'👑',name:'Chuck Dynasty',  desc:'Unlock every class'},
+  {id:'arsenal', icon:'⚔️',name:'Armed & Furry',  desc:'Unlock every weapon'}
+];
+const WEAPONS={
+  slinger:{icon:'🌰',name:'Acorn Slinger',cost:0,type:'ranged',
+    desc:'Trusty acorn shots at the nearest pest.',mods:{}},
+  claws:{icon:'🐾',name:'Claws & Tail',cost:200,type:'melee',
+    desc:'Melee arc swipes ×1.8 dmg + knockback · every 4th hit: 360° tail spin',
+    mods:{dmgMult:1.8,rateMult:1.15,reach:105}},
+  shotgun:{icon:'🌻',name:'Seed Shotgun',cost:300,type:'ranged',
+    desc:'5-pellet spray · ×0.5 dmg each · short range',
+    mods:{pellets:5,dmgMult:0.5,rangeMult:0.75,rateMult:0.85,spread:0.3}},
+  rifle:{icon:'🎋',name:'Thorn Rifle',cost:350,type:'ranged',
+    desc:'×2.6 dmg · +2 pierce · long range · slow fire',
+    mods:{dmgMult:2.6,rateMult:0.5,rangeMult:1.5,pierce:2}}
+};
 const META={
   spuds:store.get('spuds',0),
   unlocks:store.get('unlocks',{classic:true}),
   cls:store.get('class','classic'),
-  perm:store.get('perm',{})
+  perm:store.get('perm',{}),
+  ach:store.get('ach',{}),
+  bossTypes:store.get('bossTypes',{}),
+  weapon:store.get('weapon','slinger'),
+  wUnlocks:store.get('wUnlocks',{slinger:true})
 };
+if(!META.wUnlocks[META.weapon])META.weapon='slinger';
+function earnAch(id){
+  if(META.ach[id])return;
+  const def=ACH_LIST.find(a=>a.id===id);
+  if(!def)return;
+  META.ach[id]=true;META.spuds+=10;saveMeta();
+  if(state){addToast('🏆 '+def.name.toUpperCase(),'Achievement · +10 🥕');Audio2.sfx.coin()}
+  renderAch();
+}
+function renderAch(){
+  const grid=$('achGrid');
+  if(!grid)return;
+  grid.innerHTML='';
+  let earned=0;
+  for(const a of ACH_LIST){
+    const has=!!META.ach[a.id];
+    if(has)earned++;
+    const el=document.createElement('span');
+    el.className='ach'+(has?'':' locked');
+    el.title=a.desc+' (+10 🥕)';
+    el.innerHTML=`<span class="ai2">${a.icon}</span>${a.name}`;
+    grid.appendChild(el);
+  }
+  $('achCount').textContent=earned+'/'+ACH_LIST.length;
+  const bal=$('spudBal');if(bal)bal.textContent='🥕 '+META.spuds;
+}
 if(!META.unlocks[META.cls])META.cls='classic';
 function permCost(p){return Math.round(p.baseCost*Math.pow(p.growth,META.perm[p.id]||0))}
 function permLevel(id){return META.perm[id]||0}
-function saveMeta(){store.set('spuds',META.spuds);store.set('unlocks',META.unlocks);store.set('class',META.cls);store.set('perm',META.perm)}
+function saveMeta(){store.set('spuds',META.spuds);store.set('unlocks',META.unlocks);store.set('class',META.cls);store.set('perm',META.perm);store.set('ach',META.ach);store.set('bossTypes',META.bossTypes);store.set('weapon',META.weapon);store.set('wUnlocks',META.wUnlocks)}
 
 /* ---------- difficulties ---------- */
 const DIFFS={
@@ -468,8 +556,8 @@ function freshState(difficulty){
     wavePlan:[],waveClock:0,
     autoStart:false,
     speed:1,
-    kills:0,cashEarned:0,towersBuilt:0,bossKills:0,cls:META.cls,
-    towers:[],enemies:[],bullets:[],eBullets:[],orbs:[],particles:[],floats:[],lightning:[],pulses:[],toasts:[],
+    kills:0,cashEarned:0,towersBuilt:0,bossKills:0,cls:META.cls,weapon:META.weapon,victory:false,endless:false,waveDamage:0,
+    towers:[],enemies:[],bullets:[],eBullets:[],orbs:[],particles:[],floats:[],lightning:[],pulses:[],toasts:[],slashes:[],
     mods:{...BASE_MODS},activeEvent:null,
     hype:0,hypeMax:100,hypeTimer:0,
     combo:0,comboTimer:0,
@@ -483,7 +571,8 @@ function freshState(difficulty){
     player:{
       x:W/2,y:H/2,r:15,speed:190,hp:100,maxHp:100,regen:0.3,lastHurt:-99,iframe:0,
       damage:14,attackSpeed:1.7,range:175,pierce:0,projectiles:1,crit:0.05,pickup:70,
-      xp:0,level:1,xpNext:10,cooldown:0
+      xp:0,level:1,xpNext:10,cooldown:0,
+      facing:1,moving:false,idleT:0,stepT:0,gesture:null,gestureT:0,gestureCd:2.5,gestureDir:1,swings:0
     },
     mouse:null
   };
@@ -575,6 +664,11 @@ function addToast(text,sub){state.toasts.push({text,sub,ttl:2.6,life:2.6})}
 function shake(m){if(!REDUCED)state.shake=Math.min(16,state.shake+m)}
 
 /* ---------- enemies ---------- */
+const ELITE_MODS=[
+  {key:'shielded',name:'SHIELDED',color:'#93c5fd',apply(e){e.armor+=12}},
+  {key:'swift',name:'SWIFT',color:'#fbbf24',apply(e){e.spd*=1.35}},
+  {key:'enraged',name:'ENRAGED',color:'#ff6b5d',apply(e){e.dmg=Math.round(e.dmg*1.5);e.spd*=1.1}}
+];
 function hpScale(){const w=state.wave;return (1+(w-1)*0.085)*(1+Math.floor((w-1)/5)*0.3)*DIFFS[state.difficulty].hp}
 function spawnEnemy(type,px,py){
   const t=ENEMY_TYPES[type],m=state.mods,D=DIFFS[state.difficulty];
@@ -601,6 +695,13 @@ function spawnEnemy(type,px,py){
     alive:true,slowTimer:0,slowFactor:1,hitFlash:0,touchCd:0,wob:rand(0,TAU),
     ai:t.ai||null,name:t.name||null,phase:'walk',phaseT:2,summonT:3.5,shootT:2.2,diveT:6,chargeDir:null,dmgMult:1
   };
+  const eliteChance=state.endless||state.wave>20?0.18:(state.wave>=13?(state.wave-12)*0.012:0);
+  if(!t.boss&&type!=='mini'&&Math.random()<eliteChance){
+    const mod=pick(ELITE_MODS);
+    e.elite=mod;
+    e.r=Math.round(e.r*1.25);e.hp*=2.5;e.reward=Math.round(e.reward*2.5);e.xp*=2;
+    mod.apply(e);
+  }
   e.maxHp=e.hp;
   state.enemies.push(e);
   return e;
@@ -618,10 +719,13 @@ function killEnemy(e){
   if(!e.alive)return;
   e.alive=false;
   state.kills++;
+  earnAch('first');
   const cash=Math.round(e.reward*state.meta.goldMult)+state.mods.killBonus;
   state.money+=cash;state.cashEarned+=cash;
   // combo
   state.combo++;state.comboTimer=2.6;
+  if(state.combo>=15)earnAch('combo15');
+  if(state.money>=2000)earnAch('rich2k');
   // hype
   state.hype=Math.min(state.hypeMax,state.hype+(e.boss?26:4)+state.mods.hypeGainBonus);
   // xp orbs
@@ -630,6 +734,9 @@ function killEnemy(e){
   spawnParticles(e.x,e.y,e.color,e.boss?50:12,e.boss?260:130,e.boss?0.9:0.55);
   if(e.boss){
     state.bossKills++;
+    earnAch('boss');
+    META.bossTypes[e.type]=1;saveMeta();
+    if(META.bossTypes.boss&&META.bossTypes.bossFox&&META.bossTypes.bossHawk)earnAch('menagerie');
     shake(10);addPulse(e.x,e.y,220,'#ff5d73');
     addFloat(e.x,e.y-30,'+$'+cash,'#ffc94d',18);
     Audio2.sfx.boss();
@@ -739,6 +846,7 @@ function hurtPlayer(dmg){
   const p=state.player;
   if(p.iframe>0)return;
   p.hp-=dmg;p.iframe=0.5;p.lastHurt=state.time;
+  state.waveDamage+=dmg;
   state.combo=Math.floor(state.combo/2);
   shake(5);Audio2.sfx.hurt();
   spawnParticles(p.x,p.y,'#ff5d73',10,150);
@@ -842,29 +950,101 @@ function updatePlayer(dt){
   p.x=clamp(p.x+dx*p.speed*dt,p.r,W-p.r);
   p.y=clamp(p.y+dy*p.speed*dt,p.r,H-p.r);
   p.iframe=Math.max(0,p.iframe-dt);
+  // waddle & idle gestures
+  p.moving=(dx!==0||dy!==0);
+  if(dx>0.01)p.facing=1;else if(dx<-0.01)p.facing=-1;
+  if(p.moving){
+    p.idleT=0;p.gesture=null;
+    p.stepT-=dt;
+    if(p.stepT<=0){p.stepT=0.17;spawnParticles(p.x-p.facing*6,p.y+p.r*0.72,'#8a7a5a',2,36,0.4)}
+  }else{
+    p.idleT+=dt;
+    if(p.gesture){
+      p.gestureT-=dt;
+      if(p.gestureT<=0)p.gesture=null;
+    }else if(p.idleT>2){
+      p.gestureCd-=dt;
+      if(p.gestureCd<=0){
+        p.gestureCd=rand(2.4,4.6);
+        const opts=p.idleT>12?['sleep','sleep','sniff','look','nibble','stretch']:['sniff','look','nibble','stretch'];
+        p.gesture=pick(opts);
+        p.gestureT=p.gesture==='nibble'?1.5:p.gesture==='sleep'?1.8:0.8;
+        p.gestureDir=Math.random()<0.5?-1:1;
+        if(p.gesture==='sleep')addFloat(p.x+12,p.y-p.r-14,'💤','#c2d4a8',14);
+        if(p.gesture==='sniff')spawnParticles(p.x+p.facing*10,p.y-4,'#d9f99d',3,30,0.5);
+      }
+    }
+  }
   // regen after 3s w/o damage
   if(state.time-p.lastHurt>3&&p.hp<p.maxHp)p.hp=Math.min(p.maxHp,p.hp+p.regen*dt);
-  // auto attack
+  // auto attack (weapon-based)
   p.cooldown-=dt;
-  const atkRate=1/(p.attackSpeed*(state.hypeTimer>0?1.4:1));
+  const w=WEAPONS[state.weapon]||WEAPONS.slinger;
+  const wm=w.mods||{};
+  const atkRate=1/(p.attackSpeed*(wm.rateMult||1)*(state.hypeTimer>0?1.4:1));
   if(p.cooldown<=0){
-    let target=null,best=p.range;
-    for(const e of state.enemies){
-      if(!e.alive)continue;
-      const d=dist(e.x,e.y,p.x,p.y);
-      if(d<best){best=d;target=e}
-    }
-    if(target){
-      const n=p.projectiles;
-      for(let i=0;i<n;i++){
-        const spread=n>1?(i-(n-1)/2)*0.16:0;
-        const isCrit=Math.random()<p.crit;
-        let dmg=p.damage*(state.hypeTimer>0?1.3:1)*(1+Math.min(0.3,state.combo*0.01));
-        if(isCrit)dmg*=2.2;
-        fireBullet({x:p.x,y:p.y,bullet:null},target,Math.round(dmg),p.pierce,{speed:430,color:isCrit?'#ffc94d':'#ffe9b3',r:isCrit?5:4,spread,isCrit});
+    const baseDmg=()=>{
+      const isCrit=Math.random()<p.crit;
+      let dmg=p.damage*(wm.dmgMult||1)*(state.hypeTimer>0?1.3:1)*(1+Math.min(0.3,state.combo*0.01));
+      if(isCrit)dmg*=2.2;
+      return{dmg:Math.round(dmg),isCrit};
+    };
+    if(w.type==='melee'){
+      const reach=(wm.reach||105)*(p.range/175);
+      let target=null,best=reach;
+      for(const e of state.enemies){
+        if(!e.alive)continue;
+        const d=dist(e.x,e.y,p.x,p.y)-e.r;
+        if(d<best){best=d;target=e}
       }
-      p.cooldown=atkRate;
-      Audio2.sfx.shoot();
+      if(target){
+        p.swings++;
+        const spin=p.swings%4===0;
+        const baseA=Math.atan2(target.y-p.y,target.x-p.x);
+        p.facing=Math.cos(baseA)>=0?1:-1;
+        let hits=0;
+        for(const e of state.enemies){
+          if(!e.alive)continue;
+          const dx2=e.x-p.x,dy2=e.y-p.y,d2=Math.hypot(dx2,dy2);
+          if(d2-e.r>reach*(spin?1.15:1))continue;
+          if(!spin){
+            let da=Math.atan2(dy2,dx2)-baseA;
+            while(da>Math.PI)da-=TAU;while(da<-Math.PI)da+=TAU;
+            if(Math.abs(da)>1.05)continue;
+          }
+          const{dmg,isCrit}=baseDmg();
+          damageEnemy(e,Math.round(dmg*(spin?1.3:1)),null,isCrit);
+          if(e.alive){
+            const kb=(e.boss?7:spin?34:24)/(d2||1);
+            e.x=clamp(e.x+dx2*kb,e.r,W-e.r);e.y=clamp(e.y+dy2*kb,e.r,H-e.r);
+          }
+          hits++;
+        }
+        state.slashes.push({x:p.x,y:p.y,r:reach,a:baseA,spin,ttl:0.18,life:0.18});
+        if(hits)spawnParticles(target.x,target.y,'#ffe9b3',4,110,0.3);
+        Audio2.sfx.swipe();
+        p.cooldown=atkRate;
+      }
+    }else{
+      const range=p.range*(wm.rangeMult||1);
+      let target=null,best=range;
+      for(const e of state.enemies){
+        if(!e.alive)continue;
+        const d=dist(e.x,e.y,p.x,p.y);
+        if(d<best){best=d;target=e}
+      }
+      if(target){
+        p.facing=target.x>=p.x?1:-1;
+        const n=p.projectiles+((wm.pellets||1)-1);
+        const spreadStep=wm.spread?wm.spread/Math.max(1,n-1):0.16;
+        for(let i=0;i<n;i++){
+          const spread=n>1?(i-(n-1)/2)*spreadStep:0;
+          const{dmg,isCrit}=baseDmg();
+          fireBullet({x:p.x,y:p.y,bullet:null},target,dmg,p.pierce+(wm.pierce||0),{speed:430,color:isCrit?'#ffc94d':'#ffe9b3',r:isCrit?5:4,spread,isCrit});
+        }
+        p.cooldown=atkRate;
+        Audio2.sfx.shoot();
+      }
     }
   }
   // orbs
@@ -961,6 +1141,7 @@ function startWave(){
   state.wavePlan=buildWavePlan(state.wave);
   state.waveClock=0;
   state.waveActive=true;
+  state.waveDamage=0;
   addToast('WAVE '+state.wave+(state.wave%5===0?' — '+ENEMY_TYPES[bossForWave(state.wave)].name:''),ev.name+' · '+ev.desc);
   if(state.wave%5===0){Audio2.sfx.boss();shake(4)}else Audio2.sfx.wave();
   updateDockState();
@@ -975,6 +1156,20 @@ function waveCleared(){
   addFloat(state.player.x,state.player.y-30,'+$'+bonus,'#ffc94d',16);
   Audio2.sfx.coin();
   if(state.wave>bestWave){bestWave=state.wave;store.set('best',bestWave)}
+  if(state.wave>=5)earnAch('w5');
+  if(state.wave>=10)earnAch('w10');
+  if(state.wave>=20)earnAch('w20');
+  if(state.wave>=30)earnAch('w30');
+  if(state.wave>=3&&state.waveDamage===0)earnAch('flawless');
+  if(state.money>=2000)earnAch('rich2k');
+  if(state.wave===20&&!state.victory){
+    state.victory=true;
+    state.mode='victory';
+    META.spuds+=150;saveMeta();renderAch();
+    $('vicSpuds').textContent='+150 🥕 VICTORY BONUS · BALANCE '+META.spuds;
+    $('victory').hidden=false;
+    Audio2.sfx.levelup();
+  }
   state.interTimer=1.8;
   updateDockState();
 }
@@ -1009,6 +1204,7 @@ function tryPlace(x,y){
   const t=makeTower(c.x,c.y,state.armed);
   state.towers.push(t);
   state.money-=cost;state.towersBuilt++;
+  if(state.towers.length>=10)earnAch('gardener');
   spawnParticles(c.x,c.y,t.color,10,100);
   addPulse(c.x,c.y,40,t.color,0.4);
   Audio2.sfx.build();
@@ -1035,6 +1231,7 @@ function upgradeTower(t){
   t.level++;
   d.upgrade(t);
   t.upgradeCost=Math.round(t.upgradeCost*1.5);
+  if(t.level>=8)earnAch('maxbloom');
   addPulse(t.x,t.y,50,'#7ee787',0.4);
   spawnParticles(t.x,t.y,'#7ee787',10,110);
   Audio2.sfx.upgrade();
@@ -1169,6 +1366,10 @@ function update(dt){
     if(p.ttl>=p.life){state.particles.splice(i,1);continue}
     p.x+=p.vx*dt;p.y+=p.vy*dt;p.vx*=(1-3*dt);p.vy*=(1-3*dt);
   }
+  for(let i=state.slashes.length-1;i>=0;i--){
+    state.slashes[i].ttl-=dt;
+    if(state.slashes[i].ttl<=0)state.slashes.splice(i,1);
+  }
   for(let i=state.floats.length-1;i>=0;i--){
     const f=state.floats[i];f.ttl+=dt;f.y-=28*dt;
     if(f.ttl>=f.life)state.floats.splice(i,1);
@@ -1279,6 +1480,10 @@ function draw(){
       ctx.strokeStyle='rgba(85,200,240,0.6)';ctx.lineWidth=1.5;
       ctx.beginPath();ctx.arc(e.x,e.y,e.r+8,0,TAU);ctx.stroke();
     }
+    if(e.elite){
+      ctx.strokeStyle=e.elite.color;ctx.lineWidth=2;ctx.setLineDash([3,4]);
+      ctx.beginPath();ctx.arc(e.x,e.y,e.r+7,0,TAU);ctx.stroke();ctx.setLineDash([]);
+    }
     if(e.ai==='charge'&&e.phase==='windup'){
       const f=0.5+0.5*Math.sin(state.time*25);
       ctx.strokeStyle=`rgba(255,107,93,${0.35+0.45*f})`;ctx.lineWidth=3;
@@ -1288,18 +1493,44 @@ function draw(){
   // player
   const p=state.player;
   if(state.mode!=='gameover'){
-    // range ring
+    // range ring (reflects equipped weapon)
+    const rw=WEAPONS[state.weapon]||WEAPONS.slinger;
+    const ringR=rw.type==='melee'?((rw.mods.reach||105)*(p.range/175)):p.range*((rw.mods&&rw.mods.rangeMult)||1);
     ctx.globalAlpha=0.06;ctx.strokeStyle='#ffe9b3';
-    ctx.beginPath();ctx.arc(p.x,p.y,p.range,0,TAU);ctx.stroke();
+    ctx.beginPath();ctx.arc(p.x,p.y,ringR,0,TAU);ctx.stroke();
     ctx.globalAlpha=1;
     // glow + body
     if(p.iframe>0&&Math.floor(state.time*18)%2===0)ctx.globalAlpha=0.35;
-    ctx.globalAlpha*=1;
     ctx.fillStyle=(CLASSES[state.cls]||CLASSES.classic).glow;
     ctx.beginPath();ctx.arc(p.x,p.y,p.r*1.5,0,TAU);ctx.fill();
+    // gesture & waddle animation
+    let rot=0,sx=1,sy=1,oy=0;
+    const tt=state.time;
+    if(p.moving){
+      rot=Math.sin(tt*13)*0.09*p.facing;
+      oy=-Math.abs(Math.sin(tt*13))*2.5;
+      sy=1+Math.sin(tt*26)*0.04;
+    }else if(p.gesture==='sniff'){sy=1+Math.sin(tt*40)*0.05;oy=-1}
+    else if(p.gesture==='look'){rot=0.2*p.gestureDir}
+    else if(p.gesture==='stretch'){const f=Math.sin((1-Math.max(0,p.gestureT)/0.8)*Math.PI);sy=1+f*0.18;sx=1-f*0.07;oy=-f*3}
+    else if(p.gesture==='sleep'){rot=0.13;sy=0.95;oy=1.5}
+    else if(p.gesture==='nibble'){rot=Math.sin(tt*18)*0.05}
+    else{sy=1+Math.sin(tt*2.2)*0.015} // gentle idle breathing
+    if(state.hypeTimer>0)rot+=Math.sin(tt*60)*0.03;
+    if(REDUCED){rot*=0.4;oy*=0.4;sx=1;sy=1}
+    ctx.save();
+    ctx.translate(p.x,p.y+oy);
+    ctx.rotate(rot);
+    ctx.scale(p.facing*sx,sy);
     ctx.font='28px system-ui,"Apple Color Emoji","Segoe UI Emoji"';
     ctx.fillStyle='#a9805b';
-    ctx.fillText('🦫',p.x,p.y+1);
+    ctx.fillText('🦫',0,1);
+    ctx.restore();
+    if(p.gesture==='nibble'){
+      ctx.font='12px system-ui,"Apple Color Emoji","Segoe UI Emoji"';
+      ctx.fillStyle='#ffb347';
+      ctx.fillText('🥕',p.x+p.facing*11,p.y+7);
+    }
     ctx.globalAlpha=1;
     // hp bar
     const bw=38,bh=4.5,bx=p.x-bw/2,by=p.y-p.r-13;
@@ -1315,6 +1546,18 @@ function draw(){
     ctx.globalAlpha=1;
     ctx.fillStyle=b.color;
     ctx.beginPath();ctx.arc(b.x,b.y,b.r,0,TAU);ctx.fill();
+  }
+  // melee slashes
+  for(const sl of state.slashes){
+    const f=Math.max(0,sl.ttl/sl.life);
+    ctx.globalAlpha=f*0.85;
+    ctx.strokeStyle=sl.spin?'#ffb347':'#ffe9b3';
+    ctx.lineWidth=sl.spin?5:4;
+    ctx.beginPath();
+    if(sl.spin)ctx.arc(sl.x,sl.y,sl.r*0.85,0,TAU);
+    else ctx.arc(sl.x,sl.y,sl.r*0.85,sl.a-1.05,sl.a+1.05);
+    ctx.stroke();
+    ctx.globalAlpha=1;
   }
   // enemy projectiles
   for(const b of state.eBullets){
@@ -1636,11 +1879,32 @@ function renderLocker(){
     el.addEventListener('click',()=>{
       Audio2.ensure();
       if(unlocked){META.cls=id;saveMeta();Audio2.sfx.click()}
-      else if(META.spuds>=c.cost){META.spuds-=c.cost;META.unlocks[id]=true;META.cls=id;saveMeta();Audio2.sfx.upgrade()}
+      else if(META.spuds>=c.cost){META.spuds-=c.cost;META.unlocks[id]=true;META.cls=id;saveMeta();Audio2.sfx.upgrade();if(Object.keys(CLASSES).every(k=>META.unlocks[k]))earnAch('classes')}
       else{Audio2.sfx.hit();return}
       renderLocker();
     });
     row.appendChild(el);
+  }
+  const wrow=$('weaponRow');wrow.innerHTML='';
+  for(const[id,c]of Object.entries(WEAPONS)){
+    const unlocked=!!META.wUnlocks[id];
+    const el=document.createElement('button');
+    el.className='ccard'+(META.weapon===id?' sel':'')+(unlocked?'':' locked');
+    let action='';
+    if(!unlocked)action=`<span class="cu${META.spuds<c.cost?' cant':''}">UNLOCK · 🥕 ${c.cost}</span>`;
+    else if(META.weapon===id)action='<span class="csel">✓ EQUIPPED</span>';
+    el.innerHTML=`<span class="ci">${c.icon}</span><span class="cn">${c.name}</span>${META.weapon===id&&unlocked?action:''}<div class="cd">${c.desc}</div>${!unlocked?action:''}`;
+    el.addEventListener('click',()=>{
+      Audio2.ensure();
+      if(unlocked){META.weapon=id;saveMeta();Audio2.sfx.click()}
+      else if(META.spuds>=c.cost){
+        META.spuds-=c.cost;META.wUnlocks[id]=true;META.weapon=id;saveMeta();Audio2.sfx.upgrade();
+        if(Object.keys(WEAPONS).every(k=>META.wUnlocks[k]))earnAch('arsenal');
+      }
+      else{Audio2.sfx.hit();return}
+      renderLocker();
+    });
+    wrow.appendChild(el);
   }
   const prow=$('permRow');prow.innerHTML='';
   for(const p of PERMS){
@@ -1657,11 +1921,27 @@ function renderLocker(){
     });
     prow.appendChild(el);
   }
+  renderAch();
 }
+$('endlessBtn').addEventListener('click',()=>{
+  Audio2.sfx.click();
+  $('victory').hidden=true;
+  state.endless=true;
+  state.mode='playing';
+  addToast('ENDLESS MODE','Elite pests join every wave');
+});
+$('vicMenuBtn').addEventListener('click',()=>{
+  Audio2.sfx.click();
+  $('victory').hidden=true;
+  state.mode='paused';
+  renderLocker();renderAch();
+  UI.menuBest.textContent=bestWave>0?'BEST WAVE · '+bestWave:'FIRST RUN — GOOD LUCK';
+  UI.menu.hidden=false;
+});
 $('menuBtn').addEventListener('click',()=>{
   Audio2.sfx.click();
   UI.gameover.hidden=true;
-  renderLocker();
+  renderLocker();renderAch();
   UI.menuBest.textContent=bestWave>0?'BEST WAVE · '+bestWave:'FIRST RUN — GOOD LUCK';
   UI.menu.hidden=false;
 });
@@ -1684,6 +1964,7 @@ function startGame(difficulty){
   UI.gameover.hidden=true;
   UI.levelup.hidden=true;
   UI.pausedOv.hidden=true;
+  $('victory').hidden=true;
   UI.towerPanel.hidden=true;
   UI.autoBtn.textContent='AUTO OFF';UI.autoBtn.classList.remove('on');
   UI.speedBtn.textContent='1×';
@@ -1713,13 +1994,14 @@ function frame(ts){
 }
 buildDock();
 renderLocker();
+renderAch();
 resize();
 UI.menuBest.textContent=bestWave>0?'BEST WAVE · '+bestWave:'FIRST RUN — GOOD LUCK';
 UI.hBest.textContent=bestWave;
 requestAnimationFrame(frame);
 
 /* test hook */
-window.__ARENA={get state(){return state},startGame,startWave,update,spawnEnemy,TOWER_TYPES,ENEMY_TYPES,PERKS,tryPlace,armTower,towerCost,makeTower:(x,y,k)=>{const t=makeTower(x,y,k);state.towers.push(t);return t},META,CLASSES,PERMS,renderLocker,saveMeta,permCost,permLevel};
+window.__ARENA={get state(){return state},startGame,startWave,update,spawnEnemy,TOWER_TYPES,ENEMY_TYPES,PERKS,tryPlace,armTower,towerCost,makeTower:(x,y,k)=>{const t=makeTower(x,y,k);state.towers.push(t);return t},META,CLASSES,PERMS,renderLocker,saveMeta,permCost,permLevel,ACH_LIST,earnAch,ELITE_MODS,WEAPONS,waveCleared:()=>waveCleared()};
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Four additions to Groundhog Arena (`arena.html`):

### Victory & Endless Mode
- Clearing **wave 20** triggers a victory screen with a +150 🥕 bonus, then optional **Endless Mode**
- In endless (and increasingly from wave 13), **elite pests** spawn — shielded / swift / enraged variants with 2.5× HP, 2.5× reward, 2× XP, and a dashed elite ring

### Achievements
- **14 persistent achievements** (wave milestones, boss hunting, flawless waves, combos, economy, collection goals), each worth +10 🥕
- Toast notifications in-game; chip grid with earned/locked states in the Burrow

### Armory — weapon classes
- 🌰 **Acorn Slinger** (default) — ranged shots
- 🐾 **Claws & Tail** — hand-to-hand: melee arc swipes at ×1.8 damage with knockback, and every 4th hit is a **360° tail spin**; rendered slash arcs
- 🌻 **Seed Shotgun** — 5-pellet spray, ×0.5 damage each, short range
- 🎋 **Thorn Rifle** — ×2.6 damage, +2 pierce, long range, slow fire
- Unlock/equip UI in the Burrow; the player's range ring reflects the equipped weapon
- Fixed a melee reach/target mismatch that caused guaranteed whiffs at the reach boundary

### Groundhog gestures
- Waddle bob with dust puffs while moving; faces movement/attack direction
- Idle gestures: sniffing, looking around, stretching, nibbling a carrot 🥕, and dozing off with floating 💤 after long idles; gentle breathing at rest
- Rage shiver during Groundhog Rage; damped under `prefers-reduced-motion`

## Testing
- Playwright suite extended to **35 checks**: victory trigger at wave 20, endless elite spawns, achievement earning, idle gestures, facing flips, melee hits without bullets, tail-spin cadence, shotgun pellet count, armory rendering — all pass with **zero console errors**
- Burrow (classes + armory + achievements), melee tail-spin combat, and victory screens visually verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XatLZk4edckWE1X3n3tvJk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XatLZk4edckWE1X3n3tvJk)_