### PR TITLE
Seasonal calendar (Halloween & Winter), audio controls, and run history

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ A polished single-file hybrid of tower defense and arena survival. Pilot the gro
 - **Meta-progression** — runs bank 🥕 Carrots based on waves, kills, and boss takedowns; spend them in the Burrow on **4 playable classes** (Classic, Burly, Hawkeye, Hoarder Chuck) and **3 permanent upgrade tracks** (starting cash, damage, XP gain) — all persisted between sessions
 - **11 pest types** — rats, mosquitoes, boars, splitting rabbits, loot raccoons, weaving vipers, dash-striking bats, skunks (stink cloud on death slows tower fire), and quilled hedgehogs (death burst of quills) — plus **3 rotating bosses** every 5 waves, each with its own AI pattern and HP bar: the charging Grizzly, the minion-summoning Fox, and the feather-strafing Hawk
 - **Enemy visual polish** — spawn-in pop, direction-facing sprites, waddle wobble, pulsing boss glow, elite rings
-- **🎆 Special occasions** — during the July 4th week (auto-detected; `?party` to force) the game celebrates America's birthday: banner + daily +50 🥕 gift, fireworks on wave clears and boss kills, star-spangled elite rings, and the Hawk becomes the LIBERTY EAGLE with red-white-and-blue feathers. A "Grand Finale" wave event rains celebratory fireworks on pests year-round
+- **🎆 Seasonal calendar** — three auto-detected special occasions (`?season=july4|halloween|winter` to force, `?noparty` to disable), each with a menu banner, a daily +50 🥕 gift, themed fireworks, and seasonal elite rings:
+  - **July 4th week** — America's-birthday celebration, fireworks on wave clears and boss kills, and the Hawk becomes the LIBERTY EAGLE with red-white-and-blue feathers
+  - **Halloween Haunt** (Oct 24–31) — pumpkin-strewn moonlit yard with drifting fog, 👻 ghost pest variants, 🍬 candy cash drops, and the PHANTOM FOX
+  - **Winter Festival** (Dec 20–Jan 2) — falling snow, snow-drift lawn, and the Grizzly becomes the POLAR WARDEN 🐻‍❄️
+  A "Grand Finale" wave event rains celebratory fireworks on pests year-round
 - **Wave modifiers** — every wave rolls a twist (Farmers Market, Morning Buzz, Cold Snap, Hailstorm, Fertile Grounds)
 - **Groundhog Rage & combo system** — kills charge a global overdrive; kill streaks stack damage bonuses
 - **Armory: 4 weapon classes** — Acorn Slinger (ranged), Claws & Tail (melee arc swipes with knockback and a 360° tail-spin every 4th hit), Seed Shotgun (5-pellet spray), Thorn Rifle (slow piercing sniper)
@@ -18,7 +22,7 @@ A polished single-file hybrid of tower defense and arena survival. Pilot the gro
 - **14 achievements** — persistent, each worth bonus carrots, shown in the Burrow
 - **A living groundhog** — waddles with dust puffs, faces its target, and when idle will sniff, look around, stretch, nibble a carrot, or doze off
 - **Juice & graphics** — hand-drawn tower bodies with aiming, recoiling barrels; soft entity shadows; additive-glow projectiles and XP orbs; a detailed lawn (mow stripes, grass tufts, flowers, stones, vignette) with drifting fireflies; particles, screen shake, floating text, chain-lightning arcs, synth SFX and a generative soundtrack (WebAudio, no assets)
-- **Quality of life** — pause, 1×/2×/3× speed, auto-start waves, **auto-spend** (AI buys and upgrades towers with spare cash), difficulty select, persistent best wave, game-over stats + instant restart, full touch/mobile support
+- **Quality of life** — pause menu with separate music/SFX toggles, 1×/2×/3× speed, auto-start waves, **auto-spend** (AI buys and upgrades towers with spare cash), difficulty select, persistent best wave, **recent-run history in the Burrow**, game-over stats + instant restart, full touch/mobile support
 - **Zero dependencies** — one self-contained HTML file, works from `file://`, GitHub Pages, or any static host
 
 ---

--- a/arena.html
+++ b/arena.html
@@ -109,6 +109,15 @@
   .ach .ai2{font-size:13px}
   #vicSpuds{color:var(--gold);font-weight:800;font-family:var(--mono);margin-bottom:10px;font-size:15px}
 
+  /* run history */
+  #runList{display:flex;flex-direction:column;gap:4px}
+  .runrow{display:flex;align-items:center;gap:10px;background:var(--panel2);border:1px solid var(--line);border-radius:8px;padding:5px 10px;font-size:11.5px}
+  .runrow .rw{font-family:var(--mono);font-weight:700;color:var(--gold);min-width:56px}
+  .runrow .rk{font-family:var(--mono);color:var(--dim)}
+  .runrow .rd{margin-left:auto;color:var(--dim);font-size:10.5px}
+  .runrow .re{color:#a78bfa;font-size:10px;font-weight:800;letter-spacing:.08em}
+  #runList .empty{color:var(--dim);font-size:11.5px;padding:2px}
+
   /* level-up cards */
   .cards{display:flex;gap:12px;justify-content:center;margin-top:20px;flex-wrap:wrap}
   .card{position:relative;flex:1;min-width:130px;max-width:160px;background:var(--panel2);border:1px solid var(--line);border-radius:14px;padding:16px 12px;cursor:pointer;transition:transform .12s ease,border-color .12s ease;text-align:center}
@@ -225,6 +234,8 @@
           <div class="perm-row" id="permRow" style="margin-top:12px"></div>
           <div class="ach-head"><em>ACHIEVEMENTS</em><span id="achCount">0/0</span></div>
           <div class="ach-grid" id="achGrid"></div>
+          <div class="ach-head"><em>RECENT RUNS</em><span></span></div>
+          <div id="runList"></div>
         </div>
       </div>
     </div>
@@ -275,6 +286,10 @@
           <span class="key">P</span> resume · <span class="key">M</span> sound · <span class="key">F</span> speed<br>
           <span class="key">Esc</span> cancel build · <span class="key">Space</span> hype
         </div>
+        <div class="diff-row" style="margin-bottom:14px">
+          <button class="diff" id="musicBtn">MUSIC ON</button>
+          <button class="diff" id="sfxBtn">SOUND ON</button>
+        </div>
         <button class="bigbtn" id="resumeBtn" style="padding:12px 34px">RESUME</button>
       </div>
     </div>
@@ -306,10 +321,35 @@ const dist=(x1,y1,x2,y2)=>Math.hypot(x2-x1,y2-y1);
 const rand=(a,b)=>a+Math.random()*(b-a);
 const pick=arr=>arr[Math.floor(Math.random()*arr.length)];
 const REDUCED=matchMedia('(prefers-reduced-motion: reduce)').matches;
-/* July 4th week special (override with ?party / ?noparty) */
-const HOLIDAY=(()=>{try{const q=new URLSearchParams(location.search);if(q.has('noparty'))return false;if(q.has('party'))return true}catch(e){}const d=new Date();return d.getMonth()===6&&d.getDate()<=7})();
+/* Seasonal calendar (override with ?season=july4|halloween|winter, ?party, ?noparty) */
+const SEASON=(()=>{
+  try{
+    const q=new URLSearchParams(location.search);
+    if(q.has('noparty'))return null;
+    const f=q.get('season');
+    if(f&&['july4','halloween','winter'].includes(f))return f;
+    if(q.has('party'))return 'july4';
+  }catch(e){}
+  const d=new Date(),m=d.getMonth(),day=d.getDate();
+  if(m===6&&day<=7)return 'july4';
+  if(m===9&&day>=24)return 'halloween';
+  if((m===11&&day>=20)||(m===0&&day<=2))return 'winter';
+  return null;
+})();
+const HOLIDAY=SEASON==='july4';
 const HOLIDAY_250=HOLIDAY&&new Date().getFullYear()===2026;
-const FW_COLORS=HOLIDAY?['#ff4d5e','#ffffff','#5b8cff']:['#ffb347','#a3e635','#55c8f0','#f472b6'];
+const SEASON_INFO={
+  july4:{sub:'Fireworks specials active all week',fw:['#ff4d5e','#ffffff','#5b8cff']},
+  halloween:{sub:'Ghost pests & candy drops — spooky week',fw:['#ff8c00','#a855f7','#84cc16']},
+  winter:{sub:'Snowfall, gifts & the Polar Warden',fw:['#bae6fd','#ffffff','#60a5fa']}
+};
+function seasonBanner(){
+  if(SEASON==='july4')return HOLIDAY_250?'🎆 HAPPY 250TH BIRTHDAY, AMERICA! 🎆':'🎆 4TH OF JULY WEEK 🎆';
+  if(SEASON==='halloween')return '🎃 HALLOWEEN HAUNT 🎃';
+  if(SEASON==='winter')return '❄️ WINTER FESTIVAL ❄️';
+  return '';
+}
+const FW_COLORS=SEASON?SEASON_INFO[SEASON].fw:['#ffb347','#a3e635','#55c8f0','#f472b6'];
 
 /* ---------- persistence ---------- */
 const store={
@@ -319,12 +359,12 @@ const store={
 
 /* ---------- audio ---------- */
 const Audio2=(()=>{
-  let actx=null,master=null,musicGain=null,enabled=store.get('sound',true),musicTimer=null,step=0,lastShot=0;
+  let actx=null,master=null,musicGain=null,enabled=store.get('sound',true),musicOn=store.get('music',true),musicTimer=null,step=0,lastShot=0;
   function ensure(){
     try{
       if(!actx){actx=new (window.AudioContext||window.webkitAudioContext)();
         master=actx.createGain();master.gain.value=enabled?0.5:0;master.connect(actx.destination);
-        musicGain=actx.createGain();musicGain.gain.value=0.5;musicGain.connect(master);
+        musicGain=actx.createGain();musicGain.gain.value=musicOn?0.5:0;musicGain.connect(master);
         startMusic();}
       if(actx.state==='suspended')actx.resume();
     }catch(e){}
@@ -375,7 +415,8 @@ const Audio2=(()=>{
     },120);
   }
   function toggle(){enabled=!enabled;store.set('sound',enabled);if(master)master.gain.value=enabled?0.5:0;ensure();return enabled}
-  return{ensure,sfx,toggle,isOn:()=>enabled};
+  function toggleMusic(){musicOn=!musicOn;store.set('music',musicOn);if(musicGain)musicGain.gain.value=musicOn?0.5:0;ensure();return musicOn}
+  return{ensure,sfx,toggle,toggleMusic,isOn:()=>enabled,isMusicOn:()=>musicOn};
 })();
 
 /* ---------- tower definitions ---------- */
@@ -551,6 +592,20 @@ function earnAch(id){
   META.ach[id]=true;META.spuds+=10;saveMeta();
   if(state){addToast('🏆 '+def.name.toUpperCase(),'Achievement · +10 🥕');Audio2.sfx.coin()}
   renderAch();
+  renderRuns();
+}
+function renderRuns(){
+  const el=$('runList');
+  if(!el)return;
+  const runs=store.get('runs',[]);
+  if(!runs.length){el.innerHTML='<div class="empty">No runs yet — enter the yard!</div>';return}
+  el.innerHTML=runs.map(r=>{
+    const d=new Date(r.t);
+    const when=(d.getMonth()+1)+'/'+d.getDate()+' '+String(d.getHours()).padStart(2,'0')+':'+String(d.getMinutes()).padStart(2,'0');
+    const ci=(CLASSES[r.cls]||CLASSES.classic).icon;
+    const wi=(WEAPONS[r.weapon]||WEAPONS.slinger).icon;
+    return `<div class="runrow"><span>${ci}${wi}</span><span class="rw">WAVE ${r.wave}</span><span class="rk">${r.kills} kills · LV ${r.level}</span>${r.endless?'<span class="re">ENDLESS</span>':''}<span class="rd">${when}</span></div>`;
+  }).join('');
 }
 function renderAch(){
   const grid=$('achGrid');
@@ -702,6 +757,23 @@ const bgCanvas=document.createElement('canvas');bgCanvas.width=W;bgCanvas.height
   b.strokeStyle='rgba(58,81,34,0.22)';b.lineWidth=1;
   for(let x=0;x<=W;x+=GRID){b.beginPath();b.moveTo(x+0.5,0);b.lineTo(x+0.5,H);b.stroke()}
   for(let y=0;y<=H;y+=GRID){b.beginPath();b.moveTo(0,y+0.5);b.lineTo(W,y+0.5);b.stroke()}
+  // seasonal touches
+  if(typeof SEASON!=='undefined'&&SEASON==='halloween'){
+    b.globalAlpha=0.14;b.fillStyle='#1a0a24';b.fillRect(0,0,W,H);
+    b.globalAlpha=0.9;b.font='22px system-ui,"Apple Color Emoji","Segoe UI Emoji"';b.textAlign='center';
+    for(let i=0;i<4;i++)b.fillText('🎃',rand(50,W-50),rand(60,H-40));
+    b.globalAlpha=0.5;b.fillStyle='#e9e4d0';
+    b.beginPath();b.arc(W-90,70,26,0,TAU);b.fill();
+    b.globalAlpha=1;
+  }else if(typeof SEASON!=='undefined'&&SEASON==='winter'){
+    for(let i=0;i<18;i++){
+      b.globalAlpha=rand(0.05,0.11);b.fillStyle='#e8f2ff';
+      b.beginPath();b.ellipse(rand(30,W-30),rand(30,H-30),rand(18,48),rand(9,22),rand(0,TAU),0,TAU);b.fill();
+    }
+    b.globalAlpha=0.95;b.font='24px system-ui,"Apple Color Emoji","Segoe UI Emoji"';b.textAlign='center';
+    b.fillText('⛄',rand(60,W-60),rand(70,H-60));
+    b.globalAlpha=1;
+  }
   // vignette
   const v=b.createRadialGradient(W/2,H/2,H*0.42,W/2,H/2,H*0.95);
   v.addColorStop(0,'rgba(0,0,0,0)');v.addColorStop(1,'rgba(0,0,0,0.42)');
@@ -810,6 +882,9 @@ function spawnEnemy(type,px,py){
     moveType:t.move||null,dashT:1+rand(0,1.2),dashing:0,stink:!!t.stink,quills:!!t.quills,spawnT:0.3
   };
   if(HOLIDAY&&type==='bossHawk')e.name='LIBERTY EAGLE';
+  if(SEASON==='halloween'&&type==='bossFox'){e.name='PHANTOM FOX';e.color='#a855f7'}
+  if(SEASON==='winter'&&type==='boss'){e.name='POLAR WARDEN';e.icon='🐻‍❄️';e.color='#bae6fd'}
+  if(SEASON==='halloween'&&type==='grunt'&&Math.random()<0.2){e.icon='👻';e.color='#c4b5fd';e.spd*=1.12}
   const eliteChance=state.endless||state.wave>20?0.18:(state.wave>=13?(state.wave-12)*0.012:0);
   if(!t.boss&&type!=='mini'&&Math.random()<eliteChance){
     const mod=pick(ELITE_MODS);
@@ -835,6 +910,7 @@ function killEnemy(e){
   e.alive=false;
   state.kills++;
   earnAch('first');
+  if(SEASON==='halloween'&&Math.random()<0.12){state.money+=3;state.candyDrops=(state.candyDrops||0)+1;addFloat(e.x,e.y-14,'🍬 +$3','#ff8c00',12)}
   const cash=Math.round(e.reward*state.meta.goldMult)+state.mods.killBonus;
   state.money+=cash;state.cashEarned+=cash;
   // combo
@@ -853,7 +929,7 @@ function killEnemy(e){
     META.bossTypes[e.type]=1;saveMeta();
     if(META.bossTypes.boss&&META.bossTypes.bossFox&&META.bossTypes.bossHawk)earnAch('menagerie');
     shake(10);addPulse(e.x,e.y,220,'#ff5d73');
-    celebrate(HOLIDAY?3:1);
+    celebrate(SEASON?3:1);
     addFloat(e.x,e.y-30,'+$'+cash,'#ffc94d',18);
     Audio2.sfx.boss();
   }else if(e.type==='rich'){
@@ -1391,7 +1467,7 @@ function waveCleared(){
   if(state.mods.postWaveHeal){const p=state.player;p.hp=Math.min(p.maxHp,p.hp+state.mods.postWaveHeal)}
   state.activeEvent=null;state.mods={...BASE_MODS};
   addToast('WAVE CLEARED','+$'+bonus+' bonus');
-  if(HOLIDAY)celebrate(state.wave%5===0?4:2);
+  if(SEASON)celebrate(state.wave%5===0?4:2);
   else if(state.wave%5===0)celebrate(2);
   addFloat(state.player.x,state.player.y-30,'+$'+bonus,'#ffc94d',16);
   Audio2.sfx.coin();
@@ -1408,7 +1484,7 @@ function waveCleared(){
     META.spuds+=150;saveMeta();renderAch();
     $('vicSpuds').textContent='+150 🥕 VICTORY BONUS · BALANCE '+META.spuds;
     $('victory').hidden=false;
-    celebrate(HOLIDAY?8:5);
+    celebrate(SEASON?8:5);
     Audio2.sfx.levelup();
   }
   state.interTimer=1.8;
@@ -1551,6 +1627,12 @@ function gameOver(){
   const spuds=state.wave*4+Math.floor(state.kills/12)+state.bossKills*10;
   META.spuds+=spuds;saveMeta();
   $('goSpuds').textContent=`+${spuds} 🥕 CARROTS EARNED · BALANCE ${META.spuds}`;
+  // record run history
+  try{
+    const runs=store.get('runs',[]);
+    runs.unshift({t:Date.now(),wave:state.wave,kills:state.kills,level:state.player.level,cls:state.cls,weapon:state.weapon,endless:state.endless});
+    store.set('runs',runs.slice(0,8));
+  }catch(e){}
   UI.goWave.textContent=state.wave;
   UI.goKills.textContent=state.kills;
   UI.goCash.textContent='$'+state.cashEarned;
@@ -1732,6 +1814,26 @@ function draw(){
     ctx.globalAlpha=1;
     ctx.globalCompositeOperation='source-over';
   }
+  // seasonal weather
+  if(SEASON==='winter'&&!REDUCED){
+    ctx.fillStyle='#eef6ff';
+    for(let i=0;i<26;i++){
+      const fx=((i*137+state.time*(14+(i%5)*6))%(W+20))-10;
+      const fy=((i*61+state.time*(34+(i%4)*12))%(H+20))-10;
+      ctx.globalAlpha=0.25+((i*7)%10)/28;
+      ctx.beginPath();ctx.arc(fx,fy,0.9+(i%3),0,TAU);ctx.fill();
+    }
+    ctx.globalAlpha=1;
+  }else if(SEASON==='halloween'&&!REDUCED){
+    ctx.fillStyle='#9ca3af';
+    for(let i=0;i<4;i++){
+      const fx=((i*260+state.time*11)%(W+240))-120;
+      const fy=H*0.25+(i*97)%Math.round(H*0.55)+Math.sin(state.time*0.5+i)*18;
+      ctx.globalAlpha=0.045;
+      ctx.beginPath();ctx.ellipse(fx,fy,110,34,0,0,TAU);ctx.fill();
+    }
+    ctx.globalAlpha=1;
+  }
   // aura rings
   for(const t of state.towers){
     if(!t.aura)continue;
@@ -1871,7 +1973,7 @@ function draw(){
       ctx.beginPath();ctx.arc(e.x,e.y,e.r+8,0,TAU);ctx.stroke();
     }
     if(e.elite){
-      ctx.strokeStyle=HOLIDAY?['#ff4d5e','#ffffff','#5b8cff'][Math.floor(state.time*3+e.wob)%3]:e.elite.color;
+      ctx.strokeStyle=SEASON?FW_COLORS[Math.floor(state.time*3+e.wob)%FW_COLORS.length]:e.elite.color;
       ctx.lineWidth=2;ctx.setLineDash([3,4]);
       ctx.beginPath();ctx.arc(e.x,e.y,e.r+7,0,TAU);ctx.stroke();ctx.setLineDash([]);
     }
@@ -2283,11 +2385,20 @@ function cycleSpeed(){
   UI.speedBtn.textContent=state.speed+'×';
 }
 UI.speedBtn.addEventListener('click',()=>{Audio2.sfx.click();cycleSpeed()});
+function refreshAudioBtns(){
+  $('musicBtn').textContent=Audio2.isMusicOn()?'MUSIC ON':'MUSIC OFF';
+  $('musicBtn').classList.toggle('on',Audio2.isMusicOn());
+  $('sfxBtn').textContent=Audio2.isOn()?'SOUND ON':'SOUND OFF';
+  $('sfxBtn').classList.toggle('on',Audio2.isOn());
+  UI.soundBtn.textContent=Audio2.isOn()?'🔊':'🔇';
+}
 function togglePause(){
   if(!state||state.mode==='gameover'||state.mode==='levelup')return;
   if(state.mode==='paused'){state.mode='playing';UI.pausedOv.hidden=true}
-  else{state.mode='paused';UI.pausedOv.hidden=false}
+  else{state.mode='paused';UI.pausedOv.hidden=false;refreshAudioBtns()}
 }
+$('musicBtn').addEventListener('click',()=>{Audio2.ensure();Audio2.toggleMusic();refreshAudioBtns()});
+$('sfxBtn').addEventListener('click',()=>{Audio2.ensure();Audio2.toggle();refreshAudioBtns()});
 UI.pauseBtn.addEventListener('click',togglePause);
 UI.resumeBtn.addEventListener('click',togglePause);
 function toggleSound(){
@@ -2359,6 +2470,20 @@ function renderLocker(){
     prow.appendChild(el);
   }
   renderAch();
+  renderRuns();
+}
+function renderRuns(){
+  const el=$('runList');
+  if(!el)return;
+  const runs=store.get('runs',[]);
+  if(!runs.length){el.innerHTML='<div class="empty">No runs yet — enter the yard!</div>';return}
+  el.innerHTML=runs.map(r=>{
+    const d=new Date(r.t);
+    const when=(d.getMonth()+1)+'/'+d.getDate()+' '+String(d.getHours()).padStart(2,'0')+':'+String(d.getMinutes()).padStart(2,'0');
+    const ci=(CLASSES[r.cls]||CLASSES.classic).icon;
+    const wi=(WEAPONS[r.weapon]||WEAPONS.slinger).icon;
+    return `<div class="runrow"><span>${ci}${wi}</span><span class="rw">WAVE ${r.wave}</span><span class="rk">${r.kills} kills · LV ${r.level}</span>${r.endless?'<span class="re">ENDLESS</span>':''}<span class="rd">${when}</span></div>`;
+  }).join('');
 }
 $('endlessBtn').addEventListener('click',()=>{
   Audio2.sfx.click();
@@ -2410,8 +2535,8 @@ function startGame(difficulty){
   buildDock();
   updateDockState();
   UI.soundBtn.textContent=Audio2.isOn()?'🔊':'🔇';
-  if(HOLIDAY){
-    addToast(HOLIDAY_250?'🎆 HAPPY 250TH, AMERICA! 🎆':'🎆 HAPPY 4TH OF JULY! 🎆','Fireworks specials active — defend the yard');
+  if(SEASON){
+    addToast(seasonBanner(),SEASON_INFO[SEASON].sub);
     celebrate(3);
   }else addToast('WELCOME TO THE YARD','Place defenses, then start the wave');
 }
@@ -2433,13 +2558,13 @@ function frame(ts){
     syncHUD();
   }
 }
-if(HOLIDAY){
+if(SEASON){
   const giftKey='gift_'+new Date().toISOString().slice(0,10);
   let gift='';
-  if(!store.get(giftKey,false)){store.set(giftKey,true);META.spuds+=50;saveMeta();gift=' · +50 🥕 birthday gift claimed!'}
+  if(!store.get(giftKey,false)){store.set(giftKey,true);META.spuds+=50;saveMeta();gift=' · +50 🥕 gift claimed!'}
   const hb=$('holidayBanner');
   hb.hidden=false;
-  hb.innerHTML=(HOLIDAY_250?'🎆 HAPPY 250TH BIRTHDAY, AMERICA! 🎆':'🎆 4TH OF JULY WEEK 🎆')+'<span>Fireworks specials active all week'+gift+'</span>';
+  hb.innerHTML=seasonBanner()+'<span>'+SEASON_INFO[SEASON].sub+gift+'</span>';
 }
 buildDock();
 renderLocker();
@@ -2450,7 +2575,7 @@ UI.hBest.textContent=bestWave;
 requestAnimationFrame(frame);
 
 /* test hook */
-window.__ARENA={get state(){return state},startGame,startWave,update,spawnEnemy,TOWER_TYPES,ENEMY_TYPES,PERKS,tryPlace,armTower,towerCost,makeTower:(x,y,k)=>{const t=makeTower(x,y,k);state.towers.push(t);return t},META,CLASSES,PERMS,renderLocker,saveMeta,permCost,permLevel,ACH_LIST,earnAch,ELITE_MODS,WEAPONS,waveCleared:()=>waveCleared(),launchFirework,celebrate,burstFirework,HOLIDAY,HOLIDAY_250,WAVE_EVENTS,autoSpendTick};
+window.__ARENA={get state(){return state},startGame,startWave,update,spawnEnemy,TOWER_TYPES,ENEMY_TYPES,PERKS,tryPlace,armTower,towerCost,makeTower:(x,y,k)=>{const t=makeTower(x,y,k);state.towers.push(t);return t},META,CLASSES,PERMS,renderLocker,saveMeta,permCost,permLevel,ACH_LIST,earnAch,ELITE_MODS,WEAPONS,waveCleared:()=>waveCleared(),launchFirework,celebrate,burstFirework,HOLIDAY,HOLIDAY_250,SEASON,WAVE_EVENTS,autoSpendTick,renderRuns,Audio2};
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

### 🗓️ Seasonal calendar
Generalizes the July 4th special into a year-round system with auto-detected windows and URL overrides (`?season=july4|halloween|winter`, `?noparty` to disable). Every season gets a menu banner, a once-per-day +50 🥕 gift, a themed firework palette, seasonal elite-ring colors, and a welcome salvo.

- 🎃 **Halloween Haunt** (Oct 24–31) — pumpkin-strewn moonlit yard with drifting fog banks, 20% of rats rise as 👻 ghosts, kills have a 12% 🍬 candy cash drop, and the Fox stalks as the **PHANTOM FOX**
- ❄️ **Winter Festival** (Dec 20–Jan 2) — falling snow, snow-drift lawn with a snowman, and the Grizzly arrives as the **POLAR WARDEN** 🐻‍❄️
- 🎆 **July 4th week** — unchanged (LIBERTY EAGLE, star-spangled rings, birthday banner)

### 🔊 Audio controls
The pause menu now has independent **MUSIC** and **SOUND** toggles, both persisted — the generative soundtrack and SFX can finally be controlled separately.

### 📜 Run history
Every game over records the run (wave, kills, level, class, weapon, endless flag). The Burrow shows the **last 8 runs** with class/weapon icons and timestamps — see your progression across builds at a glance.

## Testing
- New dedicated seasons suite (**9 checks**): season detection per flag incl. `?party` back-compat, banners, ghost spawn rates, candy drops, Phantom Fox and Polar Warden skins, clean opt-out, independent music toggle, and run recording
- Main suite (**55 checks**) and July-4th suite (**5 checks**) re-run — all green, **zero console errors** across all three
- Halloween and Winter scenes visually verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XatLZk4edckWE1X3n3tvJk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XatLZk4edckWE1X3n3tvJk)_